### PR TITLE
35 write weather

### DIFF
--- a/src/main/java/com/umc/yourweather/YourweatherApplication.java
+++ b/src/main/java/com/umc/yourweather/YourweatherApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@EnableScheduling
 @SpringBootApplication
 public class YourweatherApplication {
 

--- a/src/main/java/com/umc/yourweather/YourweatherApplication.java
+++ b/src/main/java/com/umc/yourweather/YourweatherApplication.java
@@ -2,7 +2,9 @@ package com.umc.yourweather;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class YourweatherApplication {
 

--- a/src/main/java/com/umc/yourweather/api/RequestURI.java
+++ b/src/main/java/com/umc/yourweather/api/RequestURI.java
@@ -1,8 +1,10 @@
 package com.umc.yourweather.api;
 
 public class RequestURI {
+
     private static final String CURRENT_VER = "/api/v1";
     public static final String USER_URI = CURRENT_VER + "/users";
     public static final String EMAIL_URI = CURRENT_VER + "/email";
+    public static final String WEATHER_URI = CURRENT_VER + "/weather";
 
 }

--- a/src/main/java/com/umc/yourweather/controller/WeatherController.java
+++ b/src/main/java/com/umc/yourweather/controller/WeatherController.java
@@ -21,7 +21,7 @@ import java.util.List;
 @RestController
 //@RequiredArgsConstructor
 @Slf4j
-@RequestMapping(RequestURI.commonURI + "/weather")
+@RequestMapping(RequestURI.WEATHER_URI)
 public class WeatherController {
 
     private final WeatherService weatherService;

--- a/src/main/java/com/umc/yourweather/controller/WeatherController.java
+++ b/src/main/java/com/umc/yourweather/controller/WeatherController.java
@@ -2,38 +2,28 @@ package com.umc.yourweather.controller;
 
 import com.umc.yourweather.api.RequestURI;
 import com.umc.yourweather.auth.CustomUserDetails;
-import com.umc.yourweather.domain.User;
 import com.umc.yourweather.domain.Weather;
 import com.umc.yourweather.dto.ResponseDto;
-import com.umc.yourweather.dto.SignupRequestDto;
-import com.umc.yourweather.dto.UserResponseDto;
-import com.umc.yourweather.service.UserService;
+import com.umc.yourweather.dto.WeatherRequestDto;
 import com.umc.yourweather.service.WeatherService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
-//@RequiredArgsConstructor
+@RequiredArgsConstructor
 @Slf4j
 @RequestMapping(RequestURI.WEATHER_URI)
 public class WeatherController {
 
     private final WeatherService weatherService;
 
-    @Autowired
-    public WeatherController(WeatherService weatherService) {
-        this.weatherService = weatherService;
-    }
-
-    @PostMapping("/write")
-    public Weather createWeather(@RequestBody Weather weather) {
-        return weatherService.saveWeather(weather);
+    @PostMapping("/create")
+    public ResponseDto<Weather> create(@RequestBody @Valid WeatherRequestDto weatherRequestDto,
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseDto.success(weatherService.create(weatherRequestDto, userDetails));
     }
 }
 

--- a/src/main/java/com/umc/yourweather/domain/Memo.java
+++ b/src/main/java/com/umc/yourweather/domain/Memo.java
@@ -1,0 +1,27 @@
+package com.umc.yourweather.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Memo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "memo_id")
+    private Long id;
+    private Status status; //날씨 상태 enums
+    private String time;
+    private int condition;
+    private String content;
+
+
+}

--- a/src/main/java/com/umc/yourweather/domain/Memo.java
+++ b/src/main/java/com/umc/yourweather/domain/Memo.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,7 +27,7 @@ public class Memo {
 
     @Enumerated(EnumType.STRING)
     private Status status; //날씨 상태 enums
-    private String time;
+    private LocalDateTime time;
     private int condition;
     private String content;
 

--- a/src/main/java/com/umc/yourweather/domain/Memo.java
+++ b/src/main/java/com/umc/yourweather/domain/Memo.java
@@ -2,9 +2,11 @@ package com.umc.yourweather.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,6 +24,9 @@ public class Memo {
     private String time;
     private int condition;
     private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Weather weather;
 
 
 }

--- a/src/main/java/com/umc/yourweather/domain/Memo.java
+++ b/src/main/java/com/umc/yourweather/domain/Memo.java
@@ -8,6 +8,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -30,6 +31,7 @@ public class Memo {
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "weather_id")
     private Weather weather;
 
 

--- a/src/main/java/com/umc/yourweather/domain/Memo.java
+++ b/src/main/java/com/umc/yourweather/domain/Memo.java
@@ -2,6 +2,8 @@ package com.umc.yourweather.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -20,6 +22,8 @@ public class Memo {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "memo_id")
     private Long id;
+
+    @Enumerated(EnumType.STRING)
     private Status status; //날씨 상태 enums
     private String time;
     private int condition;

--- a/src/main/java/com/umc/yourweather/domain/Status.java
+++ b/src/main/java/com/umc/yourweather/domain/Status.java
@@ -1,6 +1,6 @@
 package com.umc.yourweather.domain;
 
 public enum Status {
-    SUNNY, CLOUDY, RAINY, LIGHTNING
     //맑음, 흐림, 비, 번개
+    SUNNY, CLOUDY, RAINY, LIGHTNING
 }

--- a/src/main/java/com/umc/yourweather/domain/Status.java
+++ b/src/main/java/com/umc/yourweather/domain/Status.java
@@ -1,6 +1,6 @@
 package com.umc.yourweather.domain;
 
-public enum Condition {
+public enum Status {
     SUNNY, CLOUDY, RAINY, LIGHTNING
     //맑음, 흐림, 비, 번개
 }

--- a/src/main/java/com/umc/yourweather/domain/Time.java
+++ b/src/main/java/com/umc/yourweather/domain/Time.java
@@ -1,5 +1,0 @@
-package com.umc.yourweather.domain;
-
-public enum Time {
-    DAY, NIGHT
-}

--- a/src/main/java/com/umc/yourweather/domain/User.java
+++ b/src/main/java/com/umc/yourweather/domain/User.java
@@ -16,6 +16,7 @@ public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
     private Long id;
 
     private String email;
@@ -49,7 +50,7 @@ public class User {
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
-  
+
     public String getEmail() {
         return email;
     }

--- a/src/main/java/com/umc/yourweather/domain/User.java
+++ b/src/main/java/com/umc/yourweather/domain/User.java
@@ -1,6 +1,8 @@
 package com.umc.yourweather.domain;
 
 import jakarta.persistence.*;
+import java.util.LinkedList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,6 +33,9 @@ public class User {
 
     private boolean isActivate;
 
+    @OneToMany(mappedBy = "user")
+    List<Weather> weathers = new LinkedList<>();
+
     @Builder
     public User(String email,
         String password,
@@ -49,18 +54,6 @@ public class User {
 
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public Role getRole() {
-        return role;
     }
 
     public void changePassword(String newPassword) {

--- a/src/main/java/com/umc/yourweather/domain/User.java
+++ b/src/main/java/com/umc/yourweather/domain/User.java
@@ -29,6 +29,7 @@ public class User {
 
     private String refreshToken;
 
+    @Enumerated(EnumType.STRING)
     private Role role;
 
     private boolean isActivate;

--- a/src/main/java/com/umc/yourweather/domain/User.java
+++ b/src/main/java/com/umc/yourweather/domain/User.java
@@ -1,7 +1,7 @@
 package com.umc.yourweather.domain;
 
 import jakarta.persistence.*;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -34,8 +34,8 @@ public class User {
 
     private boolean isActivate;
 
-    @OneToMany(mappedBy = "user")
-    List<Weather> weathers = new LinkedList<>();
+    @OneToMany(mappedBy = "user", cascade=CascadeType.REMOVE)
+    List<Weather> weathers = new ArrayList<>();
 
     @Builder
     public User(String email,

--- a/src/main/java/com/umc/yourweather/domain/Weather.java
+++ b/src/main/java/com/umc/yourweather/domain/Weather.java
@@ -1,7 +1,7 @@
 package com.umc.yourweather.domain;
 
 import jakarta.persistence.*;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -27,7 +27,7 @@ public class Weather {
     User user;
 
     @OneToMany(mappedBy = "weather")
-    List<Memo> memos = new LinkedList<>();
+    List<Memo> memos = new ArrayList<>();
 
     @Builder
     public Weather(int year, int month, int day, User user) {

--- a/src/main/java/com/umc/yourweather/domain/Weather.java
+++ b/src/main/java/com/umc/yourweather/domain/Weather.java
@@ -1,7 +1,7 @@
 package com.umc.yourweather.domain;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,7 +28,7 @@ public class Weather {
     private Double temperature; //온도
     private String diary; //diary? comment?기
 
-    @NotNull
+    @NotBlank
     private String datetime; //yyyyMMDD 형식으로 받아와서, 파싱해서 넣을 예정
 
     private Integer year;

--- a/src/main/java/com/umc/yourweather/domain/Weather.java
+++ b/src/main/java/com/umc/yourweather/domain/Weather.java
@@ -18,6 +18,7 @@ public class Weather {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "weather_id")
     private Long id;
 
     private String email; //PK

--- a/src/main/java/com/umc/yourweather/domain/Weather.java
+++ b/src/main/java/com/umc/yourweather/domain/Weather.java
@@ -15,6 +15,7 @@ import java.time.LocalDate;
 @Getter
 @Table(name = "Weathers")
 public class Weather {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -22,10 +23,6 @@ public class Weather {
     private String email; //PK
 
     private Status status; //날씨 상태 enums
-
-    private Time time; //낮, 밤 -> day, night enums
-    //enum 이름 추천 받아요..
-    //enum을 클래스로 따로 빼는게 맞는가? inner class로 하는게 맞는가?
 
     private Double temperature; //온도
     private String diary; //diary? comment?기
@@ -41,19 +38,18 @@ public class Weather {
 
     @Builder
     public Weather(String email,
-                   Status status,
-                   Double temperature,
-                   String diary,
-                   String datetime,
-                   Time time) {
+        Status status,
+        Double temperature,
+        String diary,
+        String datetime) {
+
         this.email = email;
         this.status = status;
         this.temperature = temperature;
         this.diary = diary;
         this.datetime = datetime; //yyyyMMDD
-        this.year =date.getYear();
-        this.month =date.getMonthValue();
-        this.day=date.getDayOfMonth();
-        this.time = time;
+        this.year = date.getYear();
+        this.month = date.getMonthValue();
+        this.day = date.getDayOfMonth();
     }
 }

--- a/src/main/java/com/umc/yourweather/domain/Weather.java
+++ b/src/main/java/com/umc/yourweather/domain/Weather.java
@@ -23,6 +23,7 @@ public class Weather {
     private int day;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
     User user;
 
     @OneToMany(mappedBy = "weather")

--- a/src/main/java/com/umc/yourweather/domain/Weather.java
+++ b/src/main/java/com/umc/yourweather/domain/Weather.java
@@ -22,25 +22,22 @@ public class Weather {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "weather_id")
     private Long id;
-    private String email; //PK
-    @NotBlank
-    private String datetime; //yyyyMMDD 형식으로 받아와서, 파싱해서 넣을 예정
-    private Integer year;
-    private Integer month;
-    private Integer day;
+    private int year;
+    private int month;
+    private int day;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    User user;
 
     @OneToMany(mappedBy = "weather")
     List<Memo> memos = new LinkedList<>();
 
-    LocalDate date = LocalDate.parse(datetime, java.time.format.DateTimeFormatter.BASIC_ISO_DATE);
-
     @Builder
-    public Weather(String email,
-        String datetime) {
-        this.email = email;
-        this.datetime = datetime; //yyyyMMDD
-        this.year = date.getYear();
-        this.month = date.getMonthValue();
-        this.day = date.getDayOfMonth();
+    public Weather(int year, int month, int day, User user, List<Memo> memos) {
+        this.year = year;
+        this.month = month;
+        this.day = day;
+        this.user = user;
+        this.memos = memos;
     }
 }

--- a/src/main/java/com/umc/yourweather/domain/Weather.java
+++ b/src/main/java/com/umc/yourweather/domain/Weather.java
@@ -2,6 +2,8 @@ package com.umc.yourweather.domain;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import java.util.LinkedList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,34 +22,22 @@ public class Weather {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "weather_id")
     private Long id;
-
     private String email; //PK
-
-    private Status status; //날씨 상태 enums
-
-    private Double temperature; //온도
-    private String diary; //diary? comment?기
-
     @NotBlank
     private String datetime; //yyyyMMDD 형식으로 받아와서, 파싱해서 넣을 예정
-
     private Integer year;
     private Integer month;
     private Integer day;
+
+    @OneToMany(mappedBy = "weather")
+    List<Memo> memos = new LinkedList<>();
 
     LocalDate date = LocalDate.parse(datetime, java.time.format.DateTimeFormatter.BASIC_ISO_DATE);
 
     @Builder
     public Weather(String email,
-        Status status,
-        Double temperature,
-        String diary,
         String datetime) {
-
         this.email = email;
-        this.status = status;
-        this.temperature = temperature;
-        this.diary = diary;
         this.datetime = datetime; //yyyyMMDD
         this.year = date.getYear();
         this.month = date.getMonthValue();

--- a/src/main/java/com/umc/yourweather/domain/Weather.java
+++ b/src/main/java/com/umc/yourweather/domain/Weather.java
@@ -1,16 +1,12 @@
 package com.umc.yourweather.domain;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
 import java.util.LinkedList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDate;
-
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -33,11 +29,10 @@ public class Weather {
     List<Memo> memos = new LinkedList<>();
 
     @Builder
-    public Weather(int year, int month, int day, User user, List<Memo> memos) {
+    public Weather(int year, int month, int day, User user) {
         this.year = year;
         this.month = month;
         this.day = day;
         this.user = user;
-        this.memos = memos;
     }
 }

--- a/src/main/java/com/umc/yourweather/domain/Weather.java
+++ b/src/main/java/com/umc/yourweather/domain/Weather.java
@@ -21,7 +21,7 @@ public class Weather {
 
     private String email; //PK
 
-    private Condition condition; //날씨 상태 enums
+    private Status status; //날씨 상태 enums
 
     private Time time; //낮, 밤 -> day, night enums
     //enum 이름 추천 받아요..
@@ -41,13 +41,13 @@ public class Weather {
 
     @Builder
     public Weather(String email,
-                   Condition condition,
+                   Status status,
                    Double temperature,
                    String diary,
                    String datetime,
                    Time time) {
         this.email = email;
-        this.condition = condition;
+        this.status = status;
         this.temperature = temperature;
         this.diary = diary;
         this.datetime = datetime; //yyyyMMDD

--- a/src/main/java/com/umc/yourweather/dto/ChangePasswordDto.java
+++ b/src/main/java/com/umc/yourweather/dto/ChangePasswordDto.java
@@ -1,11 +1,12 @@
 package com.umc.yourweather.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class ChangePasswordDto {
 
-    @NotNull
+    @NotBlank
     String password;
 }

--- a/src/main/java/com/umc/yourweather/dto/SignupRequestDto.java
+++ b/src/main/java/com/umc/yourweather/dto/SignupRequestDto.java
@@ -1,5 +1,6 @@
 package com.umc.yourweather.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.ToString;
@@ -8,11 +9,11 @@ import lombok.ToString;
 @ToString
 public class SignupRequestDto {
 
-    @NotNull
+    @NotBlank
     private String email;
     private String password;
-    @NotNull
+    @NotBlank
     private String nickname;
-    @NotNull
+    @NotBlank
     private String platform;
 }

--- a/src/main/java/com/umc/yourweather/dto/UserResponseDto.java
+++ b/src/main/java/com/umc/yourweather/dto/UserResponseDto.java
@@ -1,5 +1,6 @@
 package com.umc.yourweather.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -7,6 +8,8 @@ import lombok.Data;
 @AllArgsConstructor
 public class UserResponseDto {
 
+    @NotBlank
     private String nickname;
+    @NotBlank
     private String email;
 }

--- a/src/main/java/com/umc/yourweather/dto/WeatherRequestDto.java
+++ b/src/main/java/com/umc/yourweather/dto/WeatherRequestDto.java
@@ -1,18 +1,13 @@
 package com.umc.yourweather.dto;
 
-import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDate;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
-@AllArgsConstructor
 public class WeatherRequestDto {
 
-    @NotBlank
-    private String datetime; //yyyyMMDD 형식으로 받아와서, 파싱해서 넣을 예정
-
-    LocalDate date = LocalDate.parse(datetime, java.time.format.DateTimeFormatter.BASIC_ISO_DATE);
+    private String datetime;
+    private LocalDate date;
 
     public int getYear() {
         return date.getYear();
@@ -24,5 +19,11 @@ public class WeatherRequestDto {
 
     public int getDay() {
         return date.getDayOfMonth();
+    }
+
+    public WeatherRequestDto(String datetime) {
+        this.datetime = datetime;
+        this.date = LocalDate.parse(datetime,
+            java.time.format.DateTimeFormatter.BASIC_ISO_DATE);
     }
 }

--- a/src/main/java/com/umc/yourweather/dto/WeatherRequestDto.java
+++ b/src/main/java/com/umc/yourweather/dto/WeatherRequestDto.java
@@ -1,0 +1,28 @@
+package com.umc.yourweather.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class WeatherRequestDto {
+
+    @NotBlank
+    private String datetime; //yyyyMMDD 형식으로 받아와서, 파싱해서 넣을 예정
+
+    LocalDate date = LocalDate.parse(datetime, java.time.format.DateTimeFormatter.BASIC_ISO_DATE);
+
+    public int getYear() {
+        return date.getYear();
+    }
+
+    public int getMonth() {
+        return date.getMonthValue();
+    }
+
+    public int getDay() {
+        return date.getDayOfMonth();
+    }
+}

--- a/src/main/java/com/umc/yourweather/repository/MemoRepository.java
+++ b/src/main/java/com/umc/yourweather/repository/MemoRepository.java
@@ -1,0 +1,8 @@
+package com.umc.yourweather.repository;
+
+import com.umc.yourweather.domain.Memo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemoRepository extends JpaRepository<Memo, Long> {
+
+}

--- a/src/main/java/com/umc/yourweather/repository/WeatherRepository.java
+++ b/src/main/java/com/umc/yourweather/repository/WeatherRepository.java
@@ -1,14 +1,8 @@
 package com.umc.yourweather.repository;
 
-import com.umc.yourweather.domain.User;
 import com.umc.yourweather.domain.Weather;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
-@Repository
 
 public interface WeatherRepository extends JpaRepository<Weather, Long> {
-    void writeWeather(Weather weather) throws Exception;
 
 }

--- a/src/main/java/com/umc/yourweather/service/UserService.java
+++ b/src/main/java/com/umc/yourweather/service/UserService.java
@@ -71,6 +71,8 @@ public class UserService {
         User user = userRepository.findByEmail(userDetails.getUser().getEmail()).orElseThrow(
             () -> new IllegalArgumentException("등록된 사용자가 없습니다.")
         );
+
+        user.unActivate();
         return "회원 탈퇴 완료";
     }
 }

--- a/src/main/java/com/umc/yourweather/service/UserService.java
+++ b/src/main/java/com/umc/yourweather/service/UserService.java
@@ -68,12 +68,9 @@ public class UserService {
     }
 
     public String withdraw(CustomUserDetails userDetails) {
-  
-
-      User user = userRepository.findByEmail(userDetails.getUser().getEmail()).orElseThrow(
+        User user = userRepository.findByEmail(userDetails.getUser().getEmail()).orElseThrow(
             () -> new IllegalArgumentException("등록된 사용자가 없습니다.")
         );
-
-        return new UserResponseDto(user.getNickname(), user.getEmail());
+        return "회원 탈퇴 완료";
     }
 }

--- a/src/main/java/com/umc/yourweather/service/WeatherService.java
+++ b/src/main/java/com/umc/yourweather/service/WeatherService.java
@@ -7,9 +7,11 @@ import com.umc.yourweather.dto.WeatherRequestDto;
 import com.umc.yourweather.repository.WeatherRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class WeatherService {
 
     private final WeatherRepository weatherRepository;

--- a/src/main/java/com/umc/yourweather/service/WeatherService.java
+++ b/src/main/java/com/umc/yourweather/service/WeatherService.java
@@ -3,32 +3,27 @@ package com.umc.yourweather.service;
 import com.umc.yourweather.auth.CustomUserDetails;
 import com.umc.yourweather.domain.User;
 import com.umc.yourweather.domain.Weather;
-import com.umc.yourweather.dto.SignupRequestDto;
-import com.umc.yourweather.dto.UserResponseDto;
-import com.umc.yourweather.repository.UserRepository;
+import com.umc.yourweather.dto.WeatherRequestDto;
 import com.umc.yourweather.repository.WeatherRepository;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 
 @Service
-//@RequiredArgsConstructor
-@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class WeatherService {
 
     private final WeatherRepository weatherRepository;
 
-    @Autowired
-    public WeatherService(WeatherRepository weatherRepository) {
-        this.weatherRepository = weatherRepository;
-    }
+    public String create(WeatherRequestDto weatherRequestDto, CustomUserDetails userDetails) {
+        Weather weather = Weather.builder()
+            .user(userDetails.getUser())
+            .year(weatherRequestDto.getYear())
+            .month(weatherRequestDto.getMonth())
+            .day(weatherRequestDto.getDay())
+            .build();
 
-        return "날씨 추가 완료";
+        weatherRepository.save(weather);
+
+        return "날씨 생성 완료";
     }
 }

--- a/src/main/java/com/umc/yourweather/service/WeatherService.java
+++ b/src/main/java/com/umc/yourweather/service/WeatherService.java
@@ -16,6 +16,7 @@ public class WeatherService {
 
     private final WeatherRepository weatherRepository;
 
+    @Transactional
     public String create(WeatherRequestDto weatherRequestDto, CustomUserDetails userDetails) {
         Weather weather = Weather.builder()
             .user(userDetails.getUser())

--- a/src/main/java/com/umc/yourweather/service/WeatherService.java
+++ b/src/main/java/com/umc/yourweather/service/WeatherService.java
@@ -29,8 +29,6 @@ public class WeatherService {
         this.weatherRepository = weatherRepository;
     }
 
-    public Weather saveWeather(Weather weather) {
-
-        return weatherRepository.save(weather);
+        return "날씨 추가 완료";
     }
 }

--- a/src/test/java/com/umc/yourweather/controller/WeatherControllerTest.java
+++ b/src/test/java/com/umc/yourweather/controller/WeatherControllerTest.java
@@ -1,0 +1,31 @@
+package com.umc.yourweather.controller;
+
+import com.umc.yourweather.dto.WeatherRequestDto;
+import com.umc.yourweather.service.WeatherService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class WeatherControllerTest {
+
+    @Test
+    @DisplayName("yyyymmdd 형태의 날짜를 분류")
+    void createWeather() {
+        // given
+        WeatherRequestDto weatherRequestDto = new WeatherRequestDto("20230719");
+
+//        // when
+        int year = weatherRequestDto.getYear();
+        int month = weatherRequestDto.getMonth();
+        int day = weatherRequestDto.getDay();
+
+//        // then
+        Assertions.assertEquals(year, 2023);
+        Assertions.assertEquals(month, 07);
+        Assertions.assertEquals(day, 19);
+    }
+
+}


### PR DESCRIPTION
## Description
> Weather 추가 기능 

## Main Features
- `/api/v1/weather/create` 요청 시 해당 날짜의 Weather 추가 
-  기존의 write 에서 create으로 변경
- 양방향 관계 설정
- 전반적인 리팩토링 

## Others
- 프론트 쪽에서 yyyymmdd 형태로 날짜를 전달해주어야 합니다. 
해당 형태의 날짜는 서버에서 year, month, day의 형태로 분류 후 Weather field에 추가해줍니다. 
기존에 언급 되었던 내용 중 하나는 매일 자정에 자동으로 날짜에 맞는 Weather 데이터를 생성하고 추가하는 것이였습니다. 
이는 `@EnableScheduling` 을 사용하여 구현할 수 있으나, 미활동 유저들이 증가하게 되면 비효율적인 데이터 베이스 사용량 증가로 이어질 수 있다는 문제점이 있었습니다. 
따라서 초기에 사용자가 메모를 추가할 당시 메모가 하나도 없다면 /create 를 호출하여 Weather를 생성하고 메모를 생성하며, 이후에는 메모만 생성하여 Weather의 memos 리스트에 추가합니다. 
- 양방향 관계를 설정하였으며 각각 User 1 <-> * Weather, Weather 1 <-> * Memo 입니다. 

