### PR TITLE
#41 signup auto login

### DIFF
--- a/src/main/java/com/umc/yourweather/config/SecurityConfig.java
+++ b/src/main/java/com/umc/yourweather/config/SecurityConfig.java
@@ -87,7 +87,8 @@ public class SecurityConfig {
 
     @Bean
     public CustomLoginFilter customLoginFilter() {
-        CustomLoginFilter customLoginFilter = new CustomLoginFilter(objectMapper);
+        CustomLoginFilter customLoginFilter = new CustomLoginFilter(objectMapper,
+                authenticationManager());
 
         customLoginFilter.setAuthenticationManager(authenticationManager());
         customLoginFilter.setAuthenticationSuccessHandler(loginSuccessHandler);
@@ -98,7 +99,8 @@ public class SecurityConfig {
 
     @Bean
     public CustomOAuthLoginFilter customOAuthLoginFilter() {
-        CustomOAuthLoginFilter customOAuthLoginFilter = new CustomOAuthLoginFilter(objectMapper);
+        CustomOAuthLoginFilter customOAuthLoginFilter = new CustomOAuthLoginFilter(objectMapper,
+                authenticationManager());
 
         customOAuthLoginFilter.setAuthenticationManager(authenticationManager());
         customOAuthLoginFilter.setAuthenticationSuccessHandler(loginSuccessHandler);

--- a/src/main/java/com/umc/yourweather/controller/UserController.java
+++ b/src/main/java/com/umc/yourweather/controller/UserController.java
@@ -11,6 +11,8 @@ import com.umc.yourweather.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,8 +30,13 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/signup")
-    public ResponseDto<User> signup(@RequestBody @Valid SignupRequestDto signupRequestDto) {
-        return ResponseDto.success(userService.signup(signupRequestDto));
+    public ResponseEntity<ResponseDto<String>> signup(@RequestBody @Valid SignupRequestDto signupRequestDto) {
+        User user = userService.signup(signupRequestDto);
+        HttpHeaders tokenHeader = userService.getTokenHeaders(user);
+
+        return ResponseEntity.ok()
+                .headers(tokenHeader)
+                .body(ResponseDto.success("회원 가입 성공"));
     }
 
     @GetMapping("/mypage")

--- a/src/main/java/com/umc/yourweather/domain/AuthDomain.java
+++ b/src/main/java/com/umc/yourweather/domain/AuthDomain.java
@@ -1,0 +1,41 @@
+package com.umc.yourweather.domain;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+
+@RequiredArgsConstructor
+public class AuthDomain {
+    private static final String CONTENT_TYPE = "application/json";
+    private static final String EMAIL_KEY = "email";
+    private static final String PASSWORD_KEY = "password";
+
+    private final ObjectMapper objectMapper;
+    private final AuthenticationManager authenticationManager;
+
+    public Authentication authentication(String contentType, String jsonBody)
+            throws JsonProcessingException {
+        // 여기서 request의 body를 ObjectMapper로 읽고 로그인 처리를 해주는 것!
+
+        // contentType이 기재되지 않았거나 application/json이 아니면 에러를 던진다.
+        if (contentType == null || !contentType.equals(CONTENT_TYPE)) {
+            throw new AuthenticationServiceException(
+                    "지원되지 않는 Content-Type입니다. " + contentType);
+        }
+
+        Map<String, String> mappedBody = objectMapper.readValue(jsonBody, Map.class);
+
+        String email = mappedBody.get(EMAIL_KEY);
+        String password = mappedBody.get(PASSWORD_KEY);
+
+        UsernamePasswordAuthenticationToken authReq = new UsernamePasswordAuthenticationToken(email,
+                password);
+        return authenticationManager.authenticate(authReq);
+    }
+}

--- a/src/main/java/com/umc/yourweather/domain/Memo.java
+++ b/src/main/java/com/umc/yourweather/domain/Memo.java
@@ -26,9 +26,13 @@ public class Memo {
     private Long id;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "weather_status")
     private Status status; //날씨 상태 enums
-    private LocalDateTime time;
-    private int condition;
+
+    @Column(name = "creation_datetime")
+    private LocalDateTime dateTime;
+
+    private int temperature;
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/umc/yourweather/domain/Weather.java
+++ b/src/main/java/com/umc/yourweather/domain/Weather.java
@@ -18,8 +18,14 @@ public class Weather {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "weather_id")
     private Long id;
+
+    @Column(name = "yyyy")
     private int year;
+
+    @Column(name = "mm")
     private int month;
+
+    @Column(name = "dd")
     private int day;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/umc/yourweather/jwt/filter/CustomLoginFilter.java
+++ b/src/main/java/com/umc/yourweather/jwt/filter/CustomLoginFilter.java
@@ -2,11 +2,10 @@ package com.umc.yourweather.jwt.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.umc.yourweather.api.RequestURI;
-import jakarta.servlet.ServletException;
+import com.umc.yourweather.domain.AuthDomain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.security.authentication.AuthenticationServiceException;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
@@ -15,47 +14,28 @@ import org.springframework.util.StreamUtils;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
 
 public class CustomLoginFilter extends AbstractAuthenticationProcessingFilter {
 
     private static final String DEFAULT_LOGIN_REQUEST_URI = RequestURI.USER_URI + "/login";
     private static final String HTTP_METHOD = "POST";
-    private static final String CONTENT_TYPE = "application/json";
-    private static final String EMAIL_KEY = "email";
-    private static final String PASSWORD_KEY = "password";
 
-    private ObjectMapper objectMapper;
+    private final AuthDomain authDomain;
 
     private static final AntPathRequestMatcher DEFAULT_LOGIN_PATH_REQUEST_MATCHER =
             new AntPathRequestMatcher(DEFAULT_LOGIN_REQUEST_URI, HTTP_METHOD);
 
-    public CustomLoginFilter(ObjectMapper objectMapper) {
+    public CustomLoginFilter(ObjectMapper objectMapper, AuthenticationManager authenticationManager) {
         super(DEFAULT_LOGIN_PATH_REQUEST_MATCHER);
-        this.objectMapper = objectMapper;
+        authDomain = new AuthDomain(objectMapper, authenticationManager);
     }
 
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request,
             HttpServletResponse response)
-            throws AuthenticationException, IOException, ServletException {
-        // 여기서 request의 body를 ObjectMapper로 읽고 로그인 처리를 해주는 것!
-
-        // contentType이 기재되지 않았거나 application/json이 아니면 에러를 던진다.
-        if (request.getContentType() == null || !request.getContentType().equals(CONTENT_TYPE)) {
-            throw new AuthenticationServiceException(
-                    "지원되지 않는 Content-Type입니다. " + request.getContentType());
-        }
-
+            throws AuthenticationException, IOException {
         String body = StreamUtils.copyToString(request.getInputStream(), StandardCharsets.UTF_8);
 
-        Map<String, String> mappedBody = objectMapper.readValue(body, Map.class);
-
-        String email = mappedBody.get(EMAIL_KEY);
-        String password = mappedBody.get(PASSWORD_KEY);
-
-        UsernamePasswordAuthenticationToken authReq = new UsernamePasswordAuthenticationToken(email,
-                password);
-        return this.getAuthenticationManager().authenticate(authReq);
+        return authDomain.authentication(request.getContentType(), body);
     }
 }

--- a/src/main/java/com/umc/yourweather/jwt/filter/CustomOAuthLoginFilter.java
+++ b/src/main/java/com/umc/yourweather/jwt/filter/CustomOAuthLoginFilter.java
@@ -2,13 +2,12 @@ package com.umc.yourweather.jwt.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.umc.yourweather.api.RequestURI;
+import com.umc.yourweather.domain.AuthDomain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
-import org.springframework.security.authentication.AuthenticationServiceException;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
@@ -19,41 +18,23 @@ public class CustomOAuthLoginFilter extends AbstractAuthenticationProcessingFilt
 
     private static final String DEFAULT_LOGIN_REQUEST_URI = RequestURI.USER_URI + "/oauth-login";
     private static final String HTTP_METHOD = "POST";
-    private static final String CONTENT_TYPE = "application/json";
-    private static final String EMAIL_KEY = "email";
-    private static final String PASSWORD_KEY = "password";
-
-    private final ObjectMapper objectMapper;
+    private final AuthDomain authDomain;
 
     private static final AntPathRequestMatcher DEFAULT_LOGIN_PATH_REQUEST_MATCHER =
             new AntPathRequestMatcher(DEFAULT_LOGIN_REQUEST_URI, HTTP_METHOD);
 
-    public CustomOAuthLoginFilter(ObjectMapper objectMapper) {
+    public CustomOAuthLoginFilter(ObjectMapper objectMapper,
+            AuthenticationManager authenticationManager) {
         super(DEFAULT_LOGIN_PATH_REQUEST_MATCHER);
-        this.objectMapper = objectMapper;
+        authDomain = new AuthDomain(objectMapper, authenticationManager);
     }
 
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request,
             HttpServletResponse response)
             throws AuthenticationException, IOException {
-        // 여기서 request의 body를 ObjectMapper로 읽고 로그인 처리를 해주는 것!
-
-        // contentType이 기재되지 않았거나 application/json이 아니면 에러를 던진다.
-        if (request.getContentType() == null || !request.getContentType().equals(CONTENT_TYPE)) {
-            throw new AuthenticationServiceException(
-                    "지원되지 않는 Content-Type입니다. " + request.getContentType());
-        }
-
         String body = StreamUtils.copyToString(request.getInputStream(), StandardCharsets.UTF_8);
 
-        Map<String, String> mappedBody = objectMapper.readValue(body, Map.class);
-
-        String email = mappedBody.get(EMAIL_KEY);
-        String password = mappedBody.get(PASSWORD_KEY);
-
-        UsernamePasswordAuthenticationToken authReq = new UsernamePasswordAuthenticationToken(email,
-                password);
-        return this.getAuthenticationManager().authenticate(authReq);
+        return authDomain.authentication(request.getContentType(), body);
     }
 }

--- a/src/main/java/com/umc/yourweather/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc/yourweather/jwt/filter/JwtAuthenticationFilter.java
@@ -107,13 +107,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private void setAuthentication(User user) {
-        String userPw = user.getPassword();
-
-        // 이 경우에는 타 플랫폼(네이버, 구글, 카카오)로 회원가입한 사람들이다.
-        // 이 사람들에게 비밀번호 필ㄷ는 의미가 없는 것이니, 대충 아무거나 막 랜덤한거로 해서 넣는다.
-        if (userPw == null) {
-            userPw = UUID.randomUUID().toString();
-        }
 
         UserDetails userDetails = new CustomUserDetails(user);
 


### PR DESCRIPTION
## Description
> 회원 가입 이후 자동 로그인이 되도록 signup을 수정했습니다.

## Main Features
- 회원 가입 이후 자동 로그인 기능 추가

## Others
- **UserService의 signup 메서드 반환타입을 User로 수정했습니다.**
  - signup 메서드를 더 두껍게 만들지 않으려면(=가독성&목적성을 해치지 않게 하려면) HttpHeaders를 만드는 부분은 따로 분리를 하는 게 좋다고 생각을 했습니다.
  - HttpHeaders에 토큰을 달아야 하는데 토큰을 생성하려면 User 정보가 필요했습니다.
  - 따라서 HttpHeaders를 만들어주는 메서드에 User를 적절히 넣어주기 위해서 signup 메서드가 User를 반환하도록 한 것입니다.

- **Weather와 Memo 엔티티들의 일부 필드에 `@Column` 어노테이션을 넣어 DB 필드 이름을 수정해줬습니다.**
  - 해당 필드들이 이미 MySQL의 예약어로 있기 때문에 DDL이 잘 작동하지 않기 때문입니다.

- CustomLoginFilter와 CustomOAuthLoginFilter는 겹치는 코드가 많았습니다. 따라서 겹치는 코드들을 따로 분리해내어 테스트가 용이하고 혹시 재사용하게 될 상황에 유연하게 대처할 수 있도록 만들었습니다.