### PR TITLE
[FEAT] prevent authentication of same account

### DIFF
--- a/src/main/java/com/umc/yourweather/config/RedisConfig.java
+++ b/src/main/java/com/umc/yourweather/config/RedisConfig.java
@@ -26,13 +26,4 @@ public class RedisConfig {
     public RedisConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(redisHost, redisPort);
     }
-
-//    @Bean
-//    public RedisTemplate<?, ?> redisTemplate() {
-//        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
-//        redisTemplate.setConnectionFactory(redisConnectionFactory());
-//        redisTemplate.setKeySerializer(new StringRedisSerializer());
-//        redisTemplate.setValueSerializer(new StringRedisSerializer());
-//        return redisTemplate;
-//    }
 }

--- a/src/main/java/com/umc/yourweather/config/RedisConfig.java
+++ b/src/main/java/com/umc/yourweather/config/RedisConfig.java
@@ -5,9 +5,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
+//import org.springframework.data.redis.core.RedisTemplate;
+//import org.springframework.data.redis.core.RedisKeyValueAdapter;
+import org.springframework.data.redis.core.RedisKeyValueAdapter.EnableKeyspaceEvents;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+//import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+@EnableRedisRepositories(enableKeyspaceEvents =
+        EnableKeyspaceEvents.ON_STARTUP)
 @Configuration
 public class RedisConfig {
 
@@ -22,12 +27,12 @@ public class RedisConfig {
         return new LettuceConnectionFactory(redisHost, redisPort);
     }
 
-    @Bean
-    public RedisTemplate<?, ?> redisTemplate() {
-        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
-        redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
-        return redisTemplate;
-    }
+//    @Bean
+//    public RedisTemplate<?, ?> redisTemplate() {
+//        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+//        redisTemplate.setConnectionFactory(redisConnectionFactory());
+//        redisTemplate.setKeySerializer(new StringRedisSerializer());
+//        redisTemplate.setValueSerializer(new StringRedisSerializer());
+//        return redisTemplate;
+//    }
 }

--- a/src/main/java/com/umc/yourweather/controller/EmailController.java
+++ b/src/main/java/com/umc/yourweather/controller/EmailController.java
@@ -23,7 +23,7 @@ public class EmailController {
     private final EmailService emailService;
 
     @GetMapping("/send")
-    @Operation(summary = "이메일 전송", description = "인증을 위한 이메일을 전송합니다. 인증코드를 유저로부터 입력받아 /certify 요청을 보내면 유효한 코드인지 알 수 있습니다.")
+    @Operation(summary = "이메일 전송", description = "인증을 위한 이메일을 전송합니다. 인증코드를 유저로부터 입력받아 /certify 요청을 보내면 유효한 코드인지 알 수 있습니다. 이메일 전송이 5번 초과되면 더 이상 시도할 수 없습니다. 5분을 기다려 캐시가 삭제되거나 혹은 다른 이메일 주소로 시도해야합니다.")
     @Parameter(name = "email", description = "메일을 보낼 사용자 이메일입니다.", in = ParameterIn.QUERY)
     public ResponseDto<Void> send(@RequestParam String email) {
         try {

--- a/src/main/java/com/umc/yourweather/domain/MessageCreator.java
+++ b/src/main/java/com/umc/yourweather/domain/MessageCreator.java
@@ -1,8 +1,6 @@
 package com.umc.yourweather.domain;
 
-import jakarta.mail.Message.RecipientType;
 import jakarta.mail.MessagingException;
-import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
 import java.io.UnsupportedEncodingException;
 import java.util.Random;

--- a/src/main/java/com/umc/yourweather/domain/entity/EmailCertify.java
+++ b/src/main/java/com/umc/yourweather/domain/entity/EmailCertify.java
@@ -1,0 +1,44 @@
+package com.umc.yourweather.domain.entity;
+
+import lombok.Builder;
+import lombok.ToString;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
+
+@RedisHash(value = "email_certify")
+@ToString
+public class EmailCertify {
+
+    @Id
+    private String id;
+
+    @Indexed
+    private final String email;
+
+    @TimeToLive
+    private final long liveSpan;
+
+    private String code;
+    private int count;
+
+    @Builder
+    public EmailCertify(String email, String code, long liveSpan) {
+        this.email = email;
+        this.code = code;
+        this.liveSpan = liveSpan;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void certifyCodeRenewal(String code) {
+        if(code == null)
+            throw new IllegalArgumentException("이메일 인증 요청 갱신 실패: 인자로 들어온 이메일 인증 코드가 null입니다.");
+
+        this.code = code;
+        this.count++;
+    }
+}

--- a/src/main/java/com/umc/yourweather/domain/entity/EmailCertify.java
+++ b/src/main/java/com/umc/yourweather/domain/entity/EmailCertify.java
@@ -1,14 +1,12 @@
 package com.umc.yourweather.domain.entity;
 
 import lombok.Builder;
-import lombok.ToString;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 import org.springframework.data.redis.core.index.Indexed;
 
 @RedisHash(value = "email_certify")
-@ToString
 public class EmailCertify {
 
     @Id

--- a/src/main/java/com/umc/yourweather/domain/entity/EmailCertify.java
+++ b/src/main/java/com/umc/yourweather/domain/entity/EmailCertify.java
@@ -36,7 +36,7 @@ public class EmailCertify {
         if(code == null)
             throw new IllegalArgumentException("이메일 인증 요청 갱신 실패: 인자로 들어온 이메일 인증 코드가 null입니다.");
 
-        if(count > 5)
+        if(count + 1 > 5)
             throw new IllegalStateException("이메일 인증 요청 갱신 실패: 인증 요청 횟수가 5회를 초과했습니다.");
 
         this.code = code;

--- a/src/main/java/com/umc/yourweather/domain/entity/EmailCertify.java
+++ b/src/main/java/com/umc/yourweather/domain/entity/EmailCertify.java
@@ -36,6 +36,9 @@ public class EmailCertify {
         if(code == null)
             throw new IllegalArgumentException("이메일 인증 요청 갱신 실패: 인자로 들어온 이메일 인증 코드가 null입니다.");
 
+        if(count > 5)
+            throw new IllegalStateException("이메일 인증 요청 갱신 실패: 인증 요청 횟수가 5회를 초과했습니다.");
+
         this.code = code;
         this.count++;
     }

--- a/src/main/java/com/umc/yourweather/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/umc/yourweather/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ public class GlobalExceptionHandler {
             UserNotFoundException.class,
             RuntimeException.class,
             WeatherNotFoundException.class,
+            IllegalStateException.class
     })
     public ResponseDto<?> handler(Exception e) {
         return ResponseDto.fail(HttpStatus.BAD_REQUEST, e.getMessage());

--- a/src/main/java/com/umc/yourweather/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/umc/yourweather/exception/GlobalExceptionHandler.java
@@ -8,8 +8,12 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler({IllegalArgumentException.class, UserNotFoundException.class,
-        RuntimeException.class, WeatherNotFoundException.class})
+    @ExceptionHandler({
+            IllegalArgumentException.class,
+            UserNotFoundException.class,
+            RuntimeException.class,
+            WeatherNotFoundException.class,
+    })
     public ResponseDto<?> handler(Exception e) {
         return ResponseDto.fail(HttpStatus.BAD_REQUEST, e.getMessage());
     }

--- a/src/main/java/com/umc/yourweather/repository/EmailCodeRepository.java
+++ b/src/main/java/com/umc/yourweather/repository/EmailCodeRepository.java
@@ -1,0 +1,10 @@
+package com.umc.yourweather.repository;
+
+import com.umc.yourweather.domain.entity.EmailCertify;
+import java.util.Optional;
+
+public interface EmailCodeRepository {
+    Optional<EmailCertify> findByEmail(String email);
+
+    EmailCertify save(EmailCertify emailCertify);
+}

--- a/src/main/java/com/umc/yourweather/repository/impl/EmailCodeRepositoryImpl.java
+++ b/src/main/java/com/umc/yourweather/repository/impl/EmailCodeRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.umc.yourweather.repository.impl;
+
+import com.umc.yourweather.domain.entity.EmailCertify;
+import com.umc.yourweather.repository.EmailCodeRepository;
+import com.umc.yourweather.repository.redis.EmailCodeRedisRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class EmailCodeRepositoryImpl implements EmailCodeRepository {
+
+    private final EmailCodeRedisRepository emailCodeRedisRepository;
+
+    @Override
+    public Optional<EmailCertify> findByEmail(String email) {
+        return emailCodeRedisRepository.findByEmail(email);
+    }
+
+    @Override
+    public EmailCertify save(EmailCertify emailCertify) {
+        return emailCodeRedisRepository.save(emailCertify);
+    }
+}

--- a/src/main/java/com/umc/yourweather/repository/redis/EmailCodeRedisRepository.java
+++ b/src/main/java/com/umc/yourweather/repository/redis/EmailCodeRedisRepository.java
@@ -1,34 +1,11 @@
 package com.umc.yourweather.repository.redis;
 
-import java.time.Duration;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
+import com.umc.yourweather.domain.entity.EmailCertify;
+import java.util.Optional;
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-@RequiredArgsConstructor
-public class EmailCodeRedisRepository {
-
-    private final StringRedisTemplate template;
-
-    @Value("${spring.redis.life}")
-    private long duration;
-
-    public String getData(String key) {
-        ValueOperations<String, String> valueOperations = template.opsForValue();
-        return valueOperations.get(key);
-    }
-
-    public void setData(String key, String value) {
-        ValueOperations<String, String> valueOperations = template.opsForValue();
-        Duration expireDuration = Duration.ofSeconds(duration);
-        valueOperations.set(key, value, expireDuration);
-
-    }
-
-    public void deleteData(String key) {
-        template.delete(key);
-    }
+public interface EmailCodeRedisRepository extends CrudRepository<EmailCertify, Long> {
+    Optional<EmailCertify> findByEmail(String email);
 }

--- a/src/main/java/com/umc/yourweather/service/EmailService.java
+++ b/src/main/java/com/umc/yourweather/service/EmailService.java
@@ -1,15 +1,19 @@
 package com.umc.yourweather.service;
 
 import com.umc.yourweather.domain.MessageCreator;
+import com.umc.yourweather.domain.entity.EmailCertify;
 import com.umc.yourweather.repository.redis.EmailCodeRedisRepository;
 import jakarta.mail.internet.MimeMessage;
+import jakarta.persistence.EntityNotFoundException;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +21,9 @@ import org.springframework.stereotype.Service;
 public class EmailService {
     private final JavaMailSender emailSender;
     private final EmailCodeRedisRepository emailCodeRedisRepository;
+
+    @Value("${spring.redis.life}")
+    private long liveSpan;
 
     @Async
     public CompletableFuture<String> sendMessage(String to) throws Exception {
@@ -35,12 +42,29 @@ public class EmailService {
         return CompletableFuture.completedFuture(code);
     }
 
+    @Transactional
     private void setCode(String email, String code) {
-        emailCodeRedisRepository.setData(email, code);
+        EmailCertify emailCertify = emailCodeRedisRepository.findByEmail(email)
+                .orElseGet(() -> {
+                    EmailCertify toSave = EmailCertify.builder()
+                            .code(code)
+                            .email(email)
+                            .liveSpan(liveSpan)
+                            .build();
+                    return emailCodeRedisRepository.save(toSave);
+                });
+
+        emailCertify.certifyCodeRenewal(code);
+        System.out.println("emailCertify = " + emailCertify);
     }
 
+    @Transactional(readOnly = true)
     public boolean certifyingData(String email, String code) {
-        String value = emailCodeRedisRepository.getData(email);
+        EmailCertify emailCertify = emailCodeRedisRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        email + " 계정의 인증 정보 조회 실패: 해당 이메일에 대한 정보가 없습니다."));
+
+        String value = emailCertify.getCode();
         return value.equals(code);
     }
 }

--- a/src/main/java/com/umc/yourweather/service/EmailService.java
+++ b/src/main/java/com/umc/yourweather/service/EmailService.java
@@ -55,7 +55,6 @@ public class EmailService {
                 });
 
         emailCertify.certifyCodeRenewal(code);
-        System.out.println("emailCertify = " + emailCertify);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/umc/yourweather/service/EmailService.java
+++ b/src/main/java/com/umc/yourweather/service/EmailService.java
@@ -2,7 +2,7 @@ package com.umc.yourweather.service;
 
 import com.umc.yourweather.domain.MessageCreator;
 import com.umc.yourweather.domain.entity.EmailCertify;
-import com.umc.yourweather.repository.redis.EmailCodeRedisRepository;
+import com.umc.yourweather.repository.EmailCodeRepository;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.concurrent.CompletableFuture;
@@ -20,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class EmailService {
     private final JavaMailSender emailSender;
-    private final EmailCodeRedisRepository emailCodeRedisRepository;
+    private final EmailCodeRepository emailCodeRepository;
 
     @Value("${spring.redis.life}")
     private long liveSpan;
@@ -44,14 +44,14 @@ public class EmailService {
 
     @Transactional
     private void setCode(String email, String code) {
-        EmailCertify emailCertify = emailCodeRedisRepository.findByEmail(email)
+        EmailCertify emailCertify = emailCodeRepository.findByEmail(email)
                 .orElseGet(() -> {
                     EmailCertify toSave = EmailCertify.builder()
                             .code(code)
                             .email(email)
                             .liveSpan(liveSpan)
                             .build();
-                    return emailCodeRedisRepository.save(toSave);
+                    return emailCodeRepository.save(toSave);
                 });
 
         emailCertify.certifyCodeRenewal(code);
@@ -60,7 +60,7 @@ public class EmailService {
 
     @Transactional(readOnly = true)
     public boolean certifyingData(String email, String code) {
-        EmailCertify emailCertify = emailCodeRedisRepository.findByEmail(email)
+        EmailCertify emailCertify = emailCodeRepository.findByEmail(email)
                 .orElseThrow(() -> new EntityNotFoundException(
                         email + " 계정의 인증 정보 조회 실패: 해당 이메일에 대한 정보가 없습니다."));
 

--- a/src/main/java/com/umc/yourweather/service/EmailService.java
+++ b/src/main/java/com/umc/yourweather/service/EmailService.java
@@ -55,6 +55,9 @@ public class EmailService {
                 });
 
         emailCertify.certifyCodeRenewal(code);
+
+        // orElseGet을 거친다면 불필요한 저장이 두 번 진행됨. 수정 필요
+        emailCodeRepository.save(emailCertify);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/umc/yourweather/repository/test/EmailCodeTestRepository.java
+++ b/src/test/java/com/umc/yourweather/repository/test/EmailCodeTestRepository.java
@@ -1,0 +1,27 @@
+package com.umc.yourweather.repository.test;
+
+import com.umc.yourweather.domain.entity.EmailCertify;
+import com.umc.yourweather.repository.EmailCodeRepository;
+import java.util.Optional;
+
+public class EmailCodeTestRepository implements EmailCodeRepository {
+
+    @Override
+    public Optional<EmailCertify> findByEmail(String email) {
+        if(email.equals("asdf@gmail.com")) {
+            EmailCertify result = EmailCertify.builder()
+                    .email(email)
+                    .code("DATA")
+                    .liveSpan(10)
+                    .build();
+            return Optional.of(result);
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public EmailCertify save(EmailCertify emailCertify) {
+        return emailCertify;
+    }
+}

--- a/src/test/java/com/umc/yourweather/service/EmailServiceTest.java
+++ b/src/test/java/com/umc/yourweather/service/EmailServiceTest.java
@@ -1,0 +1,118 @@
+package com.umc.yourweather.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.umc.yourweather.domain.entity.EmailCertify;
+import com.umc.yourweather.repository.EmailCodeRepository;
+import com.umc.yourweather.repository.test.EmailCodeTestRepository;
+import com.umc.yourweather.service.test.EmailTestService;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+class EmailServiceTest {
+
+    private final JavaMailSender javaMailSender = new JavaMailSenderImpl();
+    private final EmailCodeRepository emailCodeRepository = new EmailCodeTestRepository();
+    private final EmailService emailService = new EmailTestService(javaMailSender, emailCodeRepository);
+
+    @Test
+    @DisplayName("getEmailCertify: Redis에 일치하는 email이 없을 때")
+    public void test1() {
+        // given
+        final String email = "aaaa";
+        final String code = "EMPTY";
+
+        // when
+        EmailCertify result = emailService.getEmailCertify(email, code);
+
+        // then
+        assertEquals(code, result.getCode());
+    }
+
+    @Test
+    @DisplayName("getEmailCertify: Redis에 일치하는 email이 있을 때")
+    public void test2() {
+        // given
+        final String email = "asdf@gmail.com";
+        final String code = "EMPTY";
+
+        // when
+        EmailCertify result = emailService.getEmailCertify(email, code);
+
+        // then
+        assertNotEquals(code, result.getCode());
+        assertEquals("DATA", result.getCode());
+    }
+
+    @Test
+    @DisplayName("setCode: Redis에 일치하는 email이 없을 때")
+    public void test3() {
+        // given
+        final String email = "aaaa";
+        final String code = "CHANGED";
+
+        // when
+        EmailCertify emailCertify = emailService.setCode(email, code);
+
+        // then
+        assertEquals(code, emailCertify.getCode());
+    }
+
+    @Test
+    @DisplayName("setCode: Redis에 일치하는 email이 있을 때")
+    public void test4() {
+        // given
+        final String email = "asdf@gmail.com";
+        final String code = "CHANGED";
+
+        // when
+        EmailCertify emailCertify = emailService.setCode(email, code);
+
+        // then
+        assertEquals(code, emailCertify.getCode());
+    }
+
+    @Test
+    @DisplayName("certifyingData: Exception이 잘 throw 되는지 테스트")
+    public void test5() {
+        // given
+        final String email = "aaaa";
+        final String code = "ASDF";
+
+        // when
+
+        // then
+        assertThrows(EntityNotFoundException.class, () -> emailService.certifyingData(email, code));
+    }
+
+    @Test
+    @DisplayName("certifyingData: return 값 true 확인")
+    public void test6() {
+        // given
+        final String email = "asdf@gmail.com"; // 이미 Repository에 기록된 키
+        final String code = "DATA"; // 이미 Repository에 기록된 키에 대한 인증 코드
+
+        // when
+        boolean result = emailService.certifyingData(email, code);
+
+        // then
+        assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("certifyingData: return 값 false 확인")
+    public void test7() {
+        // given
+        final String email = "asdf@gmail.com"; // 이미 Repository에 있는 키
+        final String code = "DIFF"; // 기록된 것과 다른 인증 코드
+
+        // when
+        boolean result = emailService.certifyingData(email, code);
+
+        // then
+        assertFalse(result);
+    }
+}

--- a/src/test/java/com/umc/yourweather/service/test/EmailTestService.java
+++ b/src/test/java/com/umc/yourweather/service/test/EmailTestService.java
@@ -1,0 +1,14 @@
+package com.umc.yourweather.service.test;
+
+import com.umc.yourweather.repository.EmailCodeRepository;
+import com.umc.yourweather.service.EmailService;
+import org.springframework.mail.javamail.JavaMailSender;
+
+public class EmailTestService extends EmailService {
+
+    public EmailTestService(
+            JavaMailSender emailSender,
+            EmailCodeRepository emailCodeRepository) {
+        super(emailSender, emailCodeRepository);
+    }
+}


### PR DESCRIPTION
## Description
> 같은 이메일의 인증 요청에 대한 중복 검사 기능을 넣는 것이 주 목적이었습니다. 

> 조금 복잡한 엔티티를 넣게 되어 RedisTemplate 방식에서 RedisRepository 방식으로 이전하여 개발했습니다.

## Main Features
- 같은 이메일의 인증 요청에 대한 중복 검사
- RedisTemplate 저장 방식에서 RedisRepository로의 대대적인 로직 수정

## Others
- EmailService에 대한 테스트 코드를 작성했습니다.
- 커버리지는 클래스 100%, 메서드 85%, 라인 60% 달성했습니다.
- 여기서 달성하지 못한 메서드 15%, 라인 40%는 메일 전송 로직에 대한 것입니다.
- 해당 부분은 테스트 코드 환경에서는 다루기 어려운지라 Mock 객체(Mockito와 같은 라이브러리에 의존하는 것은 가능한 지양할 생각)를 만들어 추가적인 테스트를 할 생각입니다.