### PR TITLE
[FIX] Add response and exception to filter

### DIFF
--- a/src/main/java/com/umc/yourweather/controller/UserController.java
+++ b/src/main/java/com/umc/yourweather/controller/UserController.java
@@ -3,7 +3,7 @@ package com.umc.yourweather.controller;
 import com.umc.yourweather.api.RequestURI;
 import com.umc.yourweather.auth.CustomUserDetails;
 import com.umc.yourweather.request.ChangePasswordRequestDto;
-import com.umc.yourweather.response.SignupResponseDto;
+import com.umc.yourweather.response.AuthorizationResponseDto;
 import com.umc.yourweather.response.UserResponseDto;
 import com.umc.yourweather.response.ResponseDto;
 import com.umc.yourweather.request.SignupRequestDto;
@@ -30,8 +30,8 @@ public class UserController {
 
     @PostMapping("/signup")
     @Operation(summary = "회원 가입 api", description = "회원 가입을 합니다. 반환받은 응답 헤더에 토큰이 있습니다.")
-    public ResponseDto<SignupResponseDto> signup(@RequestBody @Valid SignupRequestDto signupRequestDto) {
-        SignupResponseDto response = userService.signup(signupRequestDto);
+    public ResponseDto<AuthorizationResponseDto> signup(@RequestBody @Valid SignupRequestDto signupRequestDto) {
+        AuthorizationResponseDto response = userService.signup(signupRequestDto);
 
         return ResponseDto.success("회원 가입 성공", response);
     }

--- a/src/main/java/com/umc/yourweather/jwt/handler/LoginFailureHandler.java
+++ b/src/main/java/com/umc/yourweather/jwt/handler/LoginFailureHandler.java
@@ -1,9 +1,12 @@
 package com.umc.yourweather.jwt.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.yourweather.response.ResponseDto;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
@@ -14,13 +17,20 @@ import java.io.IOException;
 @Component
 public class LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
             AuthenticationException exception) throws IOException, ServletException {
+
+        ResponseDto<Void> responseDto = ResponseDto.fail(HttpStatus.BAD_REQUEST, "로그인 실패. 이메일, 비밀번호를 확인해주세요.");
+
+        String result = objectMapper.writeValueAsString(responseDto);
+
         response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
         response.setCharacterEncoding("UTF-8");
-        response.setContentType("text/plain;charset=UTF-8");
-        response.getWriter().write("로그인 실패. 이메일, 비밀번호를 확인해주세요.");
+        response.setContentType("application/json");
+        response.getWriter().write(result);
         log.info("로그인에 실패했습니다. 메시지: {}", exception.getMessage());
     }
 }

--- a/src/main/java/com/umc/yourweather/response/AuthorizationResponseDto.java
+++ b/src/main/java/com/umc/yourweather/response/AuthorizationResponseDto.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor
-public class SignupResponseDto {
+public class AuthorizationResponseDto {
     private final String accessToken;
     private final String refreshToken;
 }

--- a/src/main/java/com/umc/yourweather/service/UserService.java
+++ b/src/main/java/com/umc/yourweather/service/UserService.java
@@ -4,7 +4,7 @@ import com.umc.yourweather.auth.CustomUserDetails;
 import com.umc.yourweather.domain.enums.Role;
 import com.umc.yourweather.domain.entity.User;
 import com.umc.yourweather.request.ChangePasswordRequestDto;
-import com.umc.yourweather.response.SignupResponseDto;
+import com.umc.yourweather.response.AuthorizationResponseDto;
 import com.umc.yourweather.response.UserResponseDto;
 import com.umc.yourweather.request.SignupRequestDto;
 import com.umc.yourweather.exception.UserNotFoundException;
@@ -33,7 +33,7 @@ public class UserService {
     private String refreshTokenHeader;
 
     @Transactional
-    public SignupResponseDto signup(@Valid SignupRequestDto signupRequestDto) {
+    public AuthorizationResponseDto signup(@Valid SignupRequestDto signupRequestDto) {
         String email = signupRequestDto.getEmail();
         String password = signupRequestDto.getPassword();
 
@@ -61,11 +61,11 @@ public class UserService {
         return getSignupResponse(userRepository.save(user));
     }
 
-    protected SignupResponseDto getSignupResponse(User user) {
+    protected AuthorizationResponseDto getSignupResponse(User user) {
         String accessToken = jwtTokenManager.createAccessToken(user);
         String refreshToken = jwtTokenManager.createRefreshToken();
 
-        return SignupResponseDto.builder()
+        return AuthorizationResponseDto.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();


### PR DESCRIPTION
## Description
> 필터의 LoginSuccessHandler와 LoginFailureHandler에 Reponse를 보내도록 해주었습니다.

## Main Features
- LoginSuccessHandler Response 추가
- LoginFailureHandler Response 추가

## Others
- 이전 PR에서 언급 되었듯이, 회원 가입 Response DTO의 재사용성을 고려해 login에도 사용하기로 했습니다.
- 기존의 이름이었던 SignupReponseDto라는 네이밍이 로그인에서도 사용하게 되면 다소 어색할 것으로 보였습니다.
- 따라서 SignupResponseDto -> AuthorizationResponseDto라는 이름으로 변경되었습니다!
