### PR TITLE
[FIX] reissued token move from header to body

### DIFF
--- a/src/main/java/com/umc/yourweather/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/umc/yourweather/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.umc.yourweather.exception;
 
 import com.umc.yourweather.response.ResponseDto;
+import java.io.IOException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -13,7 +14,8 @@ public class GlobalExceptionHandler {
             UserNotFoundException.class,
             RuntimeException.class,
             WeatherNotFoundException.class,
-            IllegalStateException.class
+            IllegalStateException.class,
+            IOException.class
     })
     public ResponseDto<?> handler(Exception e) {
         return ResponseDto.fail(HttpStatus.BAD_REQUEST, e.getMessage());

--- a/src/main/java/com/umc/yourweather/jwt/JwtTokenManager.java
+++ b/src/main/java/com/umc/yourweather/jwt/JwtTokenManager.java
@@ -113,7 +113,7 @@ public class JwtTokenManager {
             );
         } catch (Exception e) {
             log.error("유효하지 않은 액세스 토큰입니다.");
-            throw new IllegalArgumentException("유효하지 않은 액세스 토큰입니다.");
+            return Optional.empty();
         }
     }
 
@@ -127,7 +127,7 @@ public class JwtTokenManager {
             return true;
         } catch (Exception e) {
             log.error("유효하지 않은 Acess Token입니다." + e.getMessage());
-            throw new IllegalArgumentException("유효하지 않은 Access Token입니다.");
+            return false;
         }
     }
 
@@ -141,7 +141,7 @@ public class JwtTokenManager {
             return true;
         } catch (Exception e) {
             log.error("유효하지 않은 Refresh Token입니다." + e.getMessage());
-            throw new IllegalArgumentException("유효하지 않은 Refresh Token입니다.");
+            return false;
         }
     }
 

--- a/src/main/java/com/umc/yourweather/jwt/JwtTokenManager.java
+++ b/src/main/java/com/umc/yourweather/jwt/JwtTokenManager.java
@@ -117,7 +117,7 @@ public class JwtTokenManager {
         }
     }
 
-    public boolean isTokenValid(String token) {
+    public boolean isAccessTokenValid(String token) {
         try {
             JWT
                 .require(Algorithm.HMAC512(secretKey))
@@ -126,8 +126,22 @@ public class JwtTokenManager {
 
             return true;
         } catch (Exception e) {
-            log.error("유효하지 않은 액세스 토큰입니다." + e.getMessage());
-            return false;
+            log.error("유효하지 않은 Acess Token입니다." + e.getMessage());
+            throw new IllegalArgumentException("유효하지 않은 Access Token입니다.");
+        }
+    }
+
+    public boolean isRefreshTokenValid(String token) {
+        try {
+            JWT
+                    .require(Algorithm.HMAC512(secretKey))
+                    .build()
+                    .verify(token);
+
+            return true;
+        } catch (Exception e) {
+            log.error("유효하지 않은 Refresh Token입니다." + e.getMessage());
+            throw new IllegalArgumentException("유효하지 않은 Refresh Token입니다.");
         }
     }
 

--- a/src/main/java/com/umc/yourweather/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc/yourweather/jwt/filter/JwtAuthenticationFilter.java
@@ -56,11 +56,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         String refreshToken = jwtTokenManager.extractRefreshToken(request)
-                .filter(jwtTokenManager::isTokenValid)
+                .filter(jwtTokenManager::isRefreshTokenValid)
                 .orElse(null);
 
         String accessToken = jwtTokenManager.extractAccessToken(request)
-                .filter(jwtTokenManager::isTokenValid)
+                .filter(jwtTokenManager::isAccessTokenValid)
                 .orElse(null);
 
         if (refreshToken != null) {
@@ -68,6 +68,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // Access Token, Refresh Token 둘 다 재발행 해주는 코드가 필요.
             if (checkRefreshToken(refreshToken)) {
                 reissueToken(response, refreshToken);
+            } else {
+                throw new IllegalArgumentException("유효한 refresh token이 아닙니다.");
             }
             // 만약 refresh 토큰이 온 경우에는 더 이상 인증을 진행시키지 않고 필터 진행 자체를 끊어버린다.
             return;

--- a/src/main/java/com/umc/yourweather/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc/yourweather/jwt/filter/JwtAuthenticationFilter.java
@@ -93,7 +93,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return userRepository.findByRefreshToken(refreshToken).isPresent();
     }
 
-    private void reissueToken(HttpServletResponse response, String refreshToken) {
+    private void reissueToken(HttpServletResponse response, String refreshToken)
+            throws IOException {
         Optional<User> optionalUser = userRepository.findByRefreshToken(refreshToken);
         User user = optionalUser.orElse(null);
 

--- a/src/main/java/com/umc/yourweather/jwt/handler/LoginFailureHandler.java
+++ b/src/main/java/com/umc/yourweather/jwt/handler/LoginFailureHandler.java
@@ -23,7 +23,7 @@ public class LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
             AuthenticationException exception) throws IOException, ServletException {
 
-        ResponseDto<Void> responseDto = ResponseDto.fail(HttpStatus.BAD_REQUEST, "로그인 실패. 이메일, 비밀번호를 확인해주세요.");
+        ResponseDto<Void> responseDto = ResponseDto.fail(HttpStatus.OK, "로그인 실패. 이메일, 비밀번호를 확인해주세요.");
 
         String result = objectMapper.writeValueAsString(responseDto);
 

--- a/src/test/java/com/umc/yourweather/jwt/JwtTokenManagerTest.java
+++ b/src/test/java/com/umc/yourweather/jwt/JwtTokenManagerTest.java
@@ -2,6 +2,7 @@ package com.umc.yourweather.jwt;
 
 import com.umc.yourweather.domain.entity.User;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -58,7 +59,7 @@ class JwtTokenManagerTest {
 
     @Test
     @DisplayName("sendAccessTokenAndRefreshToken 테스트")
-    void test3() {
+    void test3() throws IOException {
         //given
         ServletWebRequest servletContainer = (ServletWebRequest) RequestContextHolder.getRequestAttributes();
         HttpServletResponse httpServletResponse = servletContainer.getResponse();

--- a/src/test/java/com/umc/yourweather/repository/test/MemoTestRepository.java
+++ b/src/test/java/com/umc/yourweather/repository/test/MemoTestRepository.java
@@ -3,6 +3,7 @@ package com.umc.yourweather.repository.test;
 import com.umc.yourweather.domain.Proportion;
 import com.umc.yourweather.domain.entity.Memo;
 import com.umc.yourweather.domain.entity.User;
+import com.umc.yourweather.domain.entity.Weather;
 import com.umc.yourweather.domain.enums.Status;
 import com.umc.yourweather.repository.MemoRepository;
 import java.time.LocalDate;
@@ -181,5 +182,10 @@ public class MemoTestRepository implements MemoRepository {
     @Override
     public void delete(Memo memo) {
 
+    }
+
+    @Override
+    public List<Memo> findByUserAndWeatherId(User user, Weather weather) {
+        return null;
     }
 }


### PR DESCRIPTION
## Description
> 재발급 토큰을 header에서 body로 이동했습니다

## Main Features
- 재발급 토큰 header에서 body로 이동.
- dto는 AuthorizationResponseDto를 사용했습니당
- 헤더에 refresh token을 담아 보낼 시 다음과 같은 응답을 받습니다.
![image](https://github.com/yourweather/yourweather-server/assets/65557784/295a104d-bb42-43f8-a242-1ae9bbf1a71b)