### PR TITLE
[FEAT] Email verification process before password recovery

### DIFF
--- a/src/main/java/com/umc/yourweather/controller/EmailController.java
+++ b/src/main/java/com/umc/yourweather/controller/EmailController.java
@@ -41,8 +41,8 @@ public class EmailController {
     @Parameter(name = "code", description = "인증코드")
     public ResponseDto<Boolean> certify(@RequestParam String email, @RequestParam String code) {
         boolean isCorrect = emailService.certifyingData(email, code);
-        return isCorrect ?
-                ResponseDto.success("이메일 인증이 성공했습니다.", isCorrect) :
-                ResponseDto.fail(HttpStatus.BAD_REQUEST, "이메일 인증에 실패했습니다. 인증코드를 다시 확인해주세요.");
+        return isCorrect
+                ? ResponseDto.success("이메일 인증이 성공했습니다.", true)
+                : ResponseDto.fail(HttpStatus.BAD_REQUEST, "이메일 인증에 실패했습니다. 인증코드를 다시 확인해주세요.");
     }
 }

--- a/src/main/java/com/umc/yourweather/controller/UserController.java
+++ b/src/main/java/com/umc/yourweather/controller/UserController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -68,6 +70,16 @@ public class UserController {
     public ResponseDto<UserResponseDto> withdraw(
         @AuthenticationPrincipal CustomUserDetails userDetails) {
         return ResponseDto.success("회원 탈퇴 성공", userService.withdraw(userDetails));
+    }
+
+    @GetMapping("/verify-user-email")
+    @Operation(summary = "이메일 검사 api", description = "비밀번호 찾기 전, 유저의 이메일(아이디)가 실제 DB에 있는 이메일과 같은지 확인을 해줍니다.")
+    public ResponseDto<Boolean> verifyEmail(
+            @RequestParam String email) {
+        Boolean isEmailPresent = userService.verifyEmail(email);
+        return isEmailPresent
+                ? ResponseDto.success("존재하는 Email 입니다.", true)
+                : ResponseDto.fail(HttpStatus.BAD_REQUEST,"존재하지 않는 Email 입니다.");
     }
 }
 

--- a/src/main/java/com/umc/yourweather/controller/UserController.java
+++ b/src/main/java/com/umc/yourweather/controller/UserController.java
@@ -8,6 +8,7 @@ import com.umc.yourweather.response.AuthorizationResponseDto;
 import com.umc.yourweather.response.UserResponseDto;
 import com.umc.yourweather.response.ResponseDto;
 import com.umc.yourweather.request.SignupRequestDto;
+import com.umc.yourweather.response.VerifyEmailResponseDto;
 import com.umc.yourweather.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -74,12 +75,15 @@ public class UserController {
 
     @GetMapping("/verify-user-email")
     @Operation(summary = "이메일 검사 api", description = "비밀번호 찾기 전, 유저의 이메일(아이디)가 실제 DB에 있는 이메일과 같은지 확인을 해줍니다.")
-    public ResponseDto<Boolean> verifyEmail(
+    public ResponseDto<VerifyEmailResponseDto> verifyEmail(
             @RequestParam String email) {
-        Boolean isEmailPresent = userService.verifyEmail(email);
-        return isEmailPresent
-                ? ResponseDto.success("존재하는 Email 입니다.", true)
-                : ResponseDto.fail(HttpStatus.BAD_REQUEST,"존재하지 않는 Email 입니다.");
+        VerifyEmailResponseDto responseDto = userService.verifyEmail(email);
+
+        boolean isOauth = responseDto.isOauth();
+
+        return isOauth
+                ? ResponseDto.fail(HttpStatus.BAD_REQUEST,"Email 검증 실패: 소셜 로그인 유저입니다.", responseDto)
+                : ResponseDto.success("Email 검증 성공: 존재하는 Email 입니다.", responseDto);
     }
 }
 

--- a/src/main/java/com/umc/yourweather/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc/yourweather/jwt/filter/JwtAuthenticationFilter.java
@@ -36,8 +36,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             RequestURI.USER_URI + "/login",
             RequestURI.USER_URI + "/signup",
             RequestURI.USER_URI + "/oauth-login",
+            RequestURI.USER_URI + "/verify-user-email",
+
             RequestURI.EMAIL_URI + "/send",
             RequestURI.EMAIL_URI + "/certify",
+
             "/swagger-ui/index.html",
             "/favicon.ico"
     };

--- a/src/main/java/com/umc/yourweather/response/ResponseDto.java
+++ b/src/main/java/com/umc/yourweather/response/ResponseDto.java
@@ -34,4 +34,8 @@ public class ResponseDto<T> {
     public static <T> ResponseDto<T> fail(HttpStatus httpStatus, String message) {
         return new ResponseDto<>(false, httpStatus.value(), message, null);
     }
+
+    public static <T> ResponseDto<T> fail(HttpStatus httpStatus, String message, T result) {
+        return new ResponseDto<>(false, httpStatus.value(), message, result);
+    }
 }

--- a/src/main/java/com/umc/yourweather/response/VerifyEmailResponseDto.java
+++ b/src/main/java/com/umc/yourweather/response/VerifyEmailResponseDto.java
@@ -1,0 +1,14 @@
+package com.umc.yourweather.response;
+
+import com.umc.yourweather.domain.enums.Platform;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class VerifyEmailResponseDto {
+    private boolean oauth;
+    private Platform platform;
+}

--- a/src/main/java/com/umc/yourweather/service/UserService.java
+++ b/src/main/java/com/umc/yourweather/service/UserService.java
@@ -111,4 +111,8 @@ public class UserService {
         user.unActivate();
         return new UserResponseDto(user.getNickname(), user.getEmail(), user.getPlatform());
     }
+
+    public Boolean verifyEmail(String email) {
+        return userRepository.findByEmail(email).isPresent();
+    }
 }

--- a/src/main/java/com/umc/yourweather/service/UserService.java
+++ b/src/main/java/com/umc/yourweather/service/UserService.java
@@ -11,7 +11,10 @@ import com.umc.yourweather.request.SignupRequestDto;
 import com.umc.yourweather.exception.UserNotFoundException;
 import com.umc.yourweather.jwt.JwtTokenManager;
 import com.umc.yourweather.repository.UserRepository;
+import com.umc.yourweather.response.VerifyEmailResponseDto;
 import jakarta.validation.Valid;
+import java.util.Arrays;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -44,19 +47,19 @@ public class UserService {
 
         // 이메일 중복 검증 로직
         userRepository.findByEmail(email).ifPresent(
-            user -> {
-                throw new RuntimeException("이미 해당 이메일로 가입된 유저가 존재합니다.");
-            }
+                user -> {
+                    throw new RuntimeException("이미 해당 이메일로 가입된 유저가 존재합니다.");
+                }
         );
 
         User user = User.builder()
-            .email(email)
-            .password(password)
-            .nickname(nickname)
-            .platform(platform)
-            .role(Role.ROLE_USER)
-            .isActivate(true)
-            .build();
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .platform(platform)
+                .role(Role.ROLE_USER)
+                .isActivate(true)
+                .build();
 
         // 회원 가입으로 DB에 데이터를 넣는 책임과 token을 제공하는 dto를 만드는 책임은 분리를 하는게 더 좋아보임
         return getSignupResponse(userRepository.save(user));
@@ -77,15 +80,15 @@ public class UserService {
 
     public UserResponseDto mypage(CustomUserDetails userDetails) {
         User user = userRepository.findByEmail(userDetails.getUser().getEmail())
-            .orElseThrow(() -> new UserNotFoundException("등록된 사용자가 없습니다."));
+                .orElseThrow(() -> new UserNotFoundException("등록된 사용자가 없습니다."));
         return new UserResponseDto(user.getNickname(), user.getEmail(), user.getPlatform());
     }
 
     @Transactional
     public String changePassword(ChangePasswordRequestDto changePasswordRequestDto,
-        CustomUserDetails userDetails) {
+            CustomUserDetails userDetails) {
         User user = userRepository.findByEmail(userDetails.getUser().getEmail())
-            .orElseThrow(() -> new UserNotFoundException("등록된 사용자가 없습니다."));
+                .orElseThrow(() -> new UserNotFoundException("등록된 사용자가 없습니다."));
 
         String password = changePasswordRequestDto.getPassword();
         user.changePassword(passwordEncoder.encode(password));
@@ -104,7 +107,7 @@ public class UserService {
     @Transactional
     public UserResponseDto withdraw(CustomUserDetails userDetails) {
         User user = userRepository.findByEmail(userDetails.getUser().getEmail()).orElseThrow(
-            () -> new UserNotFoundException("등록된 사용자가 없습니다.")
+                () -> new UserNotFoundException("등록된 사용자가 없습니다.")
         );
 
         // Unactivate
@@ -112,7 +115,27 @@ public class UserService {
         return new UserResponseDto(user.getNickname(), user.getEmail(), user.getPlatform());
     }
 
-    public Boolean verifyEmail(String email) {
-        return userRepository.findByEmail(email).isPresent();
+    public VerifyEmailResponseDto verifyEmail(String email) {
+
+        List<String> platforms = Arrays.stream(Platform.values())
+                .map(Enum::toString)
+                .toList();
+        System.out.println("platforms = " + platforms);
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(
+                        () -> new UserNotFoundException("email 검증 실패: 해당 email을 가진 유저가 없습니다."));
+
+        if(user.getPlatform().equals(Platform.YOURWEATHER))
+            return VerifyEmailResponseDto
+                    .builder()
+                    .oauth(false)
+                    .platform(Platform.YOURWEATHER)
+                    .build();
+
+        return VerifyEmailResponseDto.builder()
+                .oauth(true)
+                .platform(user.getPlatform())
+                .build();
     }
 }


### PR DESCRIPTION
## Description
> 비밀번호 찾기를 하기 전 이메일이 가입했던 이미지인지 확인해주는 api 추가

## Main Features
- 이메일 DB 검증 api

## Others
- ResponseDto의 fail 메서드를 사용하면 result는 항상 null로 갔습니다. 필요한 상황에서는 fail을 사용하더라도 그에 맞는 result를 넣어줄 수 있도록 fail 오버로딩용 메서드를 추가했습니당
