### PR TITLE
[FIX] fix password changing api

### DIFF
--- a/src/main/java/com/umc/yourweather/controller/UserController.java
+++ b/src/main/java/com/umc/yourweather/controller/UserController.java
@@ -5,6 +5,7 @@ import com.umc.yourweather.auth.CustomUserDetails;
 import com.umc.yourweather.request.ChangeNicknameRequestDto;
 import com.umc.yourweather.request.ChangePasswordRequestDto;
 import com.umc.yourweather.response.AuthorizationResponseDto;
+import com.umc.yourweather.response.ChangePasswordResponseDto;
 import com.umc.yourweather.response.UserResponseDto;
 import com.umc.yourweather.response.ResponseDto;
 import com.umc.yourweather.request.SignupRequestDto;
@@ -60,10 +61,15 @@ public class UserController {
 
     @PatchMapping("/password")
     @Operation(summary = "비밀번호 변경", description = "비밀번호 변경 API 입니다. 기존 비밀번호와 새 비밀번호를 요청 값으로 받습니다.")
-    public ResponseDto<UserResponseDto> password(
+    public ResponseDto<ChangePasswordResponseDto> password(
         @RequestBody @Valid ChangePasswordRequestDto changePasswordRequestDto,
         @AuthenticationPrincipal CustomUserDetails userDetails) {
-        return ResponseDto.success(userService.changePassword(changePasswordRequestDto, userDetails));
+        ChangePasswordResponseDto changePasswordResponseDto = userService.changePassword(
+                changePasswordRequestDto, userDetails);
+
+        return changePasswordResponseDto.isSuccess()
+                ? ResponseDto.success("비밀번호 변경 성공", changePasswordResponseDto)
+                : ResponseDto.fail(HttpStatus.BAD_REQUEST, "비밀번호 변경 실패", changePasswordResponseDto);
     }
 
     @PutMapping("/withdraw")

--- a/src/main/java/com/umc/yourweather/controller/UserController.java
+++ b/src/main/java/com/umc/yourweather/controller/UserController.java
@@ -58,8 +58,8 @@ public class UserController {
                 changeNicknameRequestDto.getNickname(), userDetails.getUser().getEmail()));
     }
 
-    @PostMapping("/password")
-    @Operation(summary = "비밀번호 변경", description = "비밀번호 변경 API 입니다. 요청으로 보낸 데이터 값을 비밀번호로 재설정합니다.")
+    @PatchMapping("/password")
+    @Operation(summary = "비밀번호 변경", description = "비밀번호 변경 API 입니다. 기존 비밀번호와 새 비밀번호를 요청 값으로 받습니다.")
     public ResponseDto<UserResponseDto> password(
         @RequestBody @Valid ChangePasswordRequestDto changePasswordRequestDto,
         @AuthenticationPrincipal CustomUserDetails userDetails) {

--- a/src/main/java/com/umc/yourweather/request/ChangePasswordRequestDto.java
+++ b/src/main/java/com/umc/yourweather/request/ChangePasswordRequestDto.java
@@ -11,7 +11,6 @@ public class ChangePasswordRequestDto {
     @NotBlank
     String password;
 
-    public ChangePasswordRequestDto(String password) {
-        this.password = password;
-    }
+    @NotBlank
+    String newPassword;
 }

--- a/src/main/java/com/umc/yourweather/response/ChangePasswordResponseDto.java
+++ b/src/main/java/com/umc/yourweather/response/ChangePasswordResponseDto.java
@@ -1,0 +1,15 @@
+package com.umc.yourweather.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ChangePasswordResponseDto {
+    private boolean success;
+    private String message;
+    private boolean occurredByDB;
+    private boolean occurredByPassword;
+}

--- a/src/main/java/com/umc/yourweather/service/UserService.java
+++ b/src/main/java/com/umc/yourweather/service/UserService.java
@@ -6,6 +6,7 @@ import com.umc.yourweather.domain.enums.Role;
 import com.umc.yourweather.domain.entity.User;
 import com.umc.yourweather.request.ChangePasswordRequestDto;
 import com.umc.yourweather.response.AuthorizationResponseDto;
+import com.umc.yourweather.response.ChangePasswordResponseDto;
 import com.umc.yourweather.response.UserResponseDto;
 import com.umc.yourweather.request.SignupRequestDto;
 import com.umc.yourweather.exception.UserNotFoundException;
@@ -85,7 +86,7 @@ public class UserService {
     }
 
     @Transactional
-    public String changePassword(ChangePasswordRequestDto changePasswordRequestDto,
+    public ChangePasswordResponseDto changePassword(ChangePasswordRequestDto changePasswordRequestDto,
             CustomUserDetails userDetails) {
 
         User user = userRepository.findByEmail(userDetails.getUser().getEmail())
@@ -96,14 +97,31 @@ public class UserService {
 
 
         if (!passwordEncoder.matches(password, user.getPassword())) {
-            throw new IllegalArgumentException("비밀번호 변경 실패: 요청으로 들어온 기존 비밀번호가 DB에 있는 정보와 일치하지 않습니다.");
+            return ChangePasswordResponseDto.builder()
+                    .success(false)
+                    .message("요청으로 들어온 기존 비밀번호가 DB에 있는 정보와 일치하지 않습니다.")
+                    .occurredByDB(true)
+                    .occurredByPassword(false)
+                    .build();
         }
 
         if (password.equals(newPassword)) {
-            throw new IllegalArgumentException("비밀번호 변경 실패: 변경하려는 비밀번호가 기존 비밀번호와 동일합니다.");
+            return ChangePasswordResponseDto.builder()
+                    .success(false)
+                    .message("변경하려는 비밀번호가 기존 비밀번호와 동일합니다.")
+                    .occurredByDB(false)
+                    .occurredByPassword(true)
+                    .build();
         }
+
         user.changePassword(passwordEncoder.encode(newPassword));
-        return "비밀번호 변경 완료";
+
+        return ChangePasswordResponseDto.builder()
+                .success(true)
+                .message("비밀번호 변경 완료")
+                .occurredByDB(false)
+                .occurredByPassword(false)
+                .build();
     }
 
     @Transactional

--- a/src/main/java/com/umc/yourweather/service/UserService.java
+++ b/src/main/java/com/umc/yourweather/service/UserService.java
@@ -91,12 +91,17 @@ public class UserService {
         User user = userRepository.findByEmail(userDetails.getUser().getEmail())
                 .orElseThrow(() -> new UserNotFoundException("등록된 사용자가 없습니다."));
 
-        String encodedRequestPassword = passwordEncoder.encode(changePasswordRequestDto.getPassword());
-        if (encodedRequestPassword.equals(user.getPassword())) {
+        String password = changePasswordRequestDto.getPassword();
+        String newPassword = changePasswordRequestDto.getNewPassword();
+
+
+        if (!passwordEncoder.matches(password, user.getPassword())) {
             throw new IllegalArgumentException("비밀번호 변경 실패: 요청으로 들어온 기존 비밀번호가 DB에 있는 정보와 일치하지 않습니다.");
         }
 
-        String newPassword = changePasswordRequestDto.getNewPassword();
+        if (password.equals(newPassword)) {
+            throw new IllegalArgumentException("비밀번호 변경 실패: 변경하려는 비밀번호가 기존 비밀번호와 동일합니다.");
+        }
         user.changePassword(passwordEncoder.encode(newPassword));
         return "비밀번호 변경 완료";
     }

--- a/src/main/java/com/umc/yourweather/service/UserService.java
+++ b/src/main/java/com/umc/yourweather/service/UserService.java
@@ -87,11 +87,17 @@ public class UserService {
     @Transactional
     public String changePassword(ChangePasswordRequestDto changePasswordRequestDto,
             CustomUserDetails userDetails) {
+
         User user = userRepository.findByEmail(userDetails.getUser().getEmail())
                 .orElseThrow(() -> new UserNotFoundException("등록된 사용자가 없습니다."));
 
-        String password = changePasswordRequestDto.getPassword();
-        user.changePassword(passwordEncoder.encode(password));
+        String encodedRequestPassword = passwordEncoder.encode(changePasswordRequestDto.getPassword());
+        if (encodedRequestPassword.equals(user.getPassword())) {
+            throw new IllegalArgumentException("비밀번호 변경 실패: 요청으로 들어온 기존 비밀번호가 DB에 있는 정보와 일치하지 않습니다.");
+        }
+
+        String newPassword = changePasswordRequestDto.getNewPassword();
+        user.changePassword(passwordEncoder.encode(newPassword));
         return "비밀번호 변경 완료";
     }
 


### PR DESCRIPTION
## Description
> 비밀번호 변경 시 기존 비밀번호와 새 비밀번호를 받아야합니다. 받아서 기존 비밀번호가 일치하는 지 검사한 후, 맞다면 새 비밀번호로 update해주고 아니라면 Response.fail을 발생시킵니다.

## Main Features
- 기존 request 폼 수정
- 비밀번호가 일치하는 지 검사한 후 맞다면 새 비밀번호로 update 아니라면 Response.fail

## Others
```json
{
  "success": true,
  "code": 0,
  "message": "string",
  "result": {
    "success": true,
    "message": "string",
    "occurredByDB": true,
    "occurredByPassword": true
  }
}
```
- 응답 폼은 이러합니다
