### PR TITLE
[FIX] Last Temperature Change Highest Temperature

### DIFF
--- a/src/main/java/com/umc/yourweather/domain/entity/Weather.java
+++ b/src/main/java/com/umc/yourweather/domain/entity/Weather.java
@@ -45,7 +45,9 @@ public class Weather {
     }
 
     public void update(Status lastStatus, int lastTemperature) {
-        this.lastStatus = lastStatus;
-        this.lastTemperature = lastTemperature;
+        if (lastTemperature >= this.lastTemperature) {
+            this.lastStatus = lastStatus;
+            this.lastTemperature = lastTemperature;
+        }
     }
 }


### PR DESCRIPTION
## Description
> Monthly api(캘린더)에 반환하는 값 중 가장 최신의 상태와 온도를 가장 높은 온도로 수정

## Main Features
- 메모 작성 시 현재 작성된 메모와 가장 높은 온도의 메모의 온도와 비교하여 현재 작성된 메모의 온도가 더 높다면 weather의 대표를 갱신해주는 로직 추가
- 만약 최고 온도를 가지고 있는 메모가 두 개 이상이라면 가장 최신에 업로드 된 메모를 weather의 대표 날씨로 설정
