### PR TITLE
feat: 메모 삭제시 웨더의 최고 기온 update 진행

### DIFF
--- a/src/main/java/com/umc/yourweather/controller/MemoController.java
+++ b/src/main/java/com/umc/yourweather/controller/MemoController.java
@@ -66,6 +66,7 @@ public class MemoController {
     @DeleteMapping("/delete/{memoId}")
     public ResponseDto<Void> delete(@PathVariable Long memoId) {
         Long weatherId = memoService.delete(memoId);
+        weatherService.update(weatherId);
         String comment = weatherService.checkMemoAndDelete(weatherId);
         return ResponseDto.success("메모 삭제 완료" + comment);
     }

--- a/src/main/java/com/umc/yourweather/domain/entity/Weather.java
+++ b/src/main/java/com/umc/yourweather/domain/entity/Weather.java
@@ -45,9 +45,9 @@ public class Weather {
     }
 
     public void update(Status lastStatus, int lastTemperature) {
-        if (lastTemperature >= this.lastTemperature) {
-            this.lastStatus = lastStatus;
-            this.lastTemperature = lastTemperature;
-        }
+//        if (lastTemperature >= this.lastTemperature) {
+        this.lastStatus = lastStatus;
+        this.lastTemperature = lastTemperature;
+//        }
     }
 }

--- a/src/main/java/com/umc/yourweather/repository/MemoRepository.java
+++ b/src/main/java/com/umc/yourweather/repository/MemoRepository.java
@@ -4,9 +4,7 @@ import com.umc.yourweather.domain.entity.Memo;
 import com.umc.yourweather.domain.entity.User;
 import com.umc.yourweather.domain.entity.Weather;
 import com.umc.yourweather.domain.enums.Status;
-import com.umc.yourweather.response.MemoItemResponseDto;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -28,4 +26,6 @@ public interface MemoRepository {
 //    List<MemoItemResponseDto> findByDateAndUser(User user, LocalDate localDate);
 
     List<Memo> findByUserAndWeatherId(User user, Weather weather);
+
+    List<Memo> findByWeatherId(Weather weather);
 }

--- a/src/main/java/com/umc/yourweather/repository/WeatherRepository.java
+++ b/src/main/java/com/umc/yourweather/repository/WeatherRepository.java
@@ -26,4 +26,6 @@ public interface WeatherRepository {
     void delete(Weather weather);
 
     List<Weather> findWeatherByDateBetweenAndUser(LocalDate startDate, LocalDate endDate, User user);
+
+    Optional<Weather> findByDateAtHighestTemperature(LocalDate localDate);
 }

--- a/src/main/java/com/umc/yourweather/repository/impl/MemoRepositoryImpl.java
+++ b/src/main/java/com/umc/yourweather/repository/impl/MemoRepositoryImpl.java
@@ -61,6 +61,11 @@ public class MemoRepositoryImpl implements MemoRepository {
         return memoJpaRepository.findByUserAndWeatherId(user, weather);
     }
 
+    @Override
+    public List<Memo> findByWeatherId(Weather weather) {
+        return memoJpaRepository.findByWeatherId(weather);
+    }
+
 //    public List<MemoItemResponseDto> findByDateAndUser(User user, LocalDate localDate) {
 //        return memoJpaRepository.findByDateAndUser(user,localDate);
 //    }

--- a/src/main/java/com/umc/yourweather/repository/impl/WeatherRepositoryImpl.java
+++ b/src/main/java/com/umc/yourweather/repository/impl/WeatherRepositoryImpl.java
@@ -57,4 +57,10 @@ public class WeatherRepositoryImpl implements WeatherRepository {
     public List<Weather> findWeatherByDateBetweenAndUser(LocalDate oneWeekAgo, LocalDate current, User user) {
         return weatherJpaRepository.findWeatherByDateBetweenAndUser(oneWeekAgo, current, user);
     }
+
+    @Override
+    public Optional<Weather> findByDateAtHighestTemperature(LocalDate localDate) {
+        return weatherJpaRepository.findByDateAtHighestTemperature(localDate);
+    }
+
 }

--- a/src/main/java/com/umc/yourweather/repository/jpa/MemoJpaRepository.java
+++ b/src/main/java/com/umc/yourweather/repository/jpa/MemoJpaRepository.java
@@ -52,4 +52,13 @@ public interface MemoJpaRepository extends JpaRepository<Memo, Long> {
     List<Memo> findByUserAndWeatherId(
             @Param("user") User user,
             @Param("weather") Weather weatherId);
+
+    @Query("SELECT m FROM Memo m "
+            + "JOIN FETCH m.weather w "
+            + "JOIN FETCH w.user u "
+            + "WHERE "
+            + "m.weather = :weather "
+            + "ORDER BY m.temperature asc")
+    List<Memo> findByWeatherId(
+            @Param("weather") Weather weatherId);
 }

--- a/src/main/java/com/umc/yourweather/repository/jpa/WeatherJpaRepository.java
+++ b/src/main/java/com/umc/yourweather/repository/jpa/WeatherJpaRepository.java
@@ -33,4 +33,13 @@ public interface WeatherJpaRepository extends JpaRepository<Weather, Long> {
             @Param("endDate") LocalDate endDate);
 
     List<Weather> findWeatherByDateBetweenAndUser(LocalDate startDate, LocalDate endDate, User user);
+
+    @Query("SELECT w FROM Weather w "
+            + "JOIN FETCH w.user u "
+            + "WHERE "
+            + "u = :user AND "
+            + "w.date = :localDate "
+            + "ORDER BY w.date asc")
+    Optional<Weather> findByDateAtHighestTemperature(
+            @Param("localDate") LocalDate localDate);
 }

--- a/src/main/java/com/umc/yourweather/service/MemoService.java
+++ b/src/main/java/com/umc/yourweather/service/MemoService.java
@@ -101,32 +101,11 @@ public class MemoService {
     public Long delete(Long memoId) {
         Memo memo = memoRepository.findById(memoId)
                 .orElseThrow(() -> new MemoNotFoundException("해당 메모가 없습니다. id =" + memoId));
+        memoRepository.delete(memo);
 
         Long weatherId = memo.getWeather().getId();
 
-        List<Memo> memoList = memoRepository.findByWeatherId(memo.getWeather());
-
-        Memo memoWithHighestTemperature = memoList.get(0); // Initialize with the first memo
-
-        for (Memo tmpMemo : memoList) {
-            if (tmpMemo.getTemperature() > memoWithHighestTemperature.getTemperature()) {
-                memoWithHighestTemperature = tmpMemo; // Update if a memo with higher temperature is found
-            }
-        }
-
-        Optional<Weather> weather = weatherRepository.findById(weatherId);
-
-//        Optional<Weather> weather = weatherRepository.findByDateAndUser(memo.getWeather().getDate(), memo.getWeather().getUser());
-
-        if (weather.isPresent()) {
-            Weather tempWeather = weather.get();
-            tempWeather.update(memoWithHighestTemperature.getStatus(), memoWithHighestTemperature.getTemperature());
-
-        }
-
-        memoRepository.delete(memo);
-
-        return memoId;
+        return weatherId;
     }
 
     @Transactional

--- a/src/main/java/com/umc/yourweather/service/WeatherService.java
+++ b/src/main/java/com/umc/yourweather/service/WeatherService.java
@@ -12,6 +12,7 @@ import com.umc.yourweather.repository.WeatherRepository;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -98,6 +99,22 @@ public class WeatherService {
         weatherRepository.delete(weather);
 
         return " (해당 날짜의 Memo가 전부 삭제되어 해당 날짜의 Weather 또한 같이 삭제되었습니다.)";
+    }
+
+    public void update(Long weatherId){
+        Weather weather = weatherRepository.findById(weatherId).orElseThrow(()
+                -> new WeatherNotFoundException("해당 아이디로 조회되는 Weather 엔티티가 존재하지 않습니다."));
+        List<Memo> memoList = weather.getMemos();
+
+        Memo memoWithHighestTemperature = memoList.get(0); // Initialize with the first memo
+
+        for (Memo tmpMemo : memoList) {
+            if (tmpMemo.getTemperature() > memoWithHighestTemperature.getTemperature()) {
+                memoWithHighestTemperature = tmpMemo; // Update if a memo with higher temperature is found
+            }
+        }
+
+        weather.update(memoWithHighestTemperature.getStatus(),memoWithHighestTemperature.getTemperature());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/umc/yourweather/service/WeatherService.java
+++ b/src/main/java/com/umc/yourweather/service/WeatherService.java
@@ -8,6 +8,7 @@ import com.umc.yourweather.domain.entity.Weather;
 import com.umc.yourweather.exception.WeatherNotFoundException;
 import com.umc.yourweather.response.*;
 import com.umc.yourweather.repository.WeatherRepository;
+
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,8 +26,7 @@ public class WeatherService {
 
 
     @Transactional
-    public MissedInputResponseDto getMissedInputs(
-            CustomUserDetails userDetails) {
+    public MissedInputResponseDto getMissedInputs(CustomUserDetails userDetails) {
 
         // 응답 변수 추가
         MissedInputResponseDto missedInputResponseDto = new MissedInputResponseDto();
@@ -45,8 +45,7 @@ public class WeatherService {
             dateIterator = dateIterator.plusDays(1);
         }
 
-        List<Weather> weathers = weatherRepository.findWeatherByDateBetweenAndUser(oneWeekAgo,
-                current,userDetails.getUser());
+        List<Weather> weathers = weatherRepository.findWeatherByDateBetweenAndUser(oneWeekAgo, current, userDetails.getUser());
 
         for (Weather weather : weathers) {
             LocalDate localDate = weather.getDate();
@@ -64,20 +63,14 @@ public class WeatherService {
         LocalDate localDate = LocalDate.now();
         MemoManager memoManager = new MemoManager();
 
-        Weather weather = weatherRepository.findByDateAndUser(localDate, user)
-                .orElseThrow(() -> new WeatherNotFoundException("오늘 날짜에 해당하는 날씨 객체가 존재하지 않습니다."));
+        Weather weather = weatherRepository.findByDateAndUser(localDate, user).orElseThrow(() -> new WeatherNotFoundException("오늘 날짜에 해당하는 날씨 객체가 존재하지 않습니다."));
 
         List<Memo> memoList = weather.getMemos();
         memoManager.isMemoListEmpty(memoList);
         String imageName = memoManager.getImageName(memoList);
 
         Memo lastMemo = memoList.get(memoList.size() - 1);
-        return HomeResponseDto.builder()
-                .nickname(user.getNickname())
-                .status(lastMemo.getStatus())
-                .temperature(lastMemo.getTemperature())
-                .imageName(imageName)
-                .build();
+        return HomeResponseDto.builder().nickname(user.getNickname()).status(lastMemo.getStatus()).temperature(lastMemo.getTemperature()).imageName(imageName).build();
 
     }
 
@@ -94,9 +87,8 @@ public class WeatherService {
 
     @Transactional
     public String checkMemoAndDelete(Long weatherId) {
-        Weather weather = weatherRepository.findById(weatherId)
-                .orElseThrow(
-                        () -> new WeatherNotFoundException("해당 아이디로 조회되는 Weather 엔티티가 존재하지 않습니다."));
+        Weather weather = weatherRepository.findById(weatherId).orElseThrow(()
+                -> new WeatherNotFoundException("해당 아이디로 조회되는 Weather 엔티티가 존재하지 않습니다."));
 
         List<Memo> memoList = weather.getMemos();
         if (memoList.size() > 0) {


### PR DESCRIPTION
## Description
> 메모 삭제/수정 시 Weather의 최고기온/최고상태 필드 update 해야함

현재 상황
- 현재 구현된 로직
 메모 삭제를 하기 전에, 메모 아이디를 통해 웨더 객체를 받아옴, 웨더 아이디를 기준으로 메모리스트를 돌아서, 최고 기온을 변수로 저장함. 알아낸 값으로 웨더 업데이트를 호출! (이것이 나의 완벽한 로직)

- memo delete를 하면 익셉션이 하나 걸림
    @Operation(summary = "메모 삭제", description = "메모 삭제을 위한 API입니다.")
    @DeleteMapping("/delete/{memoId}")
    public ResponseDto<Void> delete(@PathVariable Long memoId) {
        Long weatherId = memoService.delete(memoId);
        String comment = weatherService.checkMemoAndDelete(weatherId);
        return ResponseDto.success("메모 삭제 완료" + comment);
    }

위 코드에서 `checkMemoAndDelete`메소드에서 나오는 `해당 아이디로 조회되는 Weather 엔티티가 존재하지 않습니다.` 요기서 걸려 버림.. memo delete의 호출 순서가 잘못되었거나, 로직이 잘못된 것 같음... checkMemoAndDelete여기 안에서 분기처리를 하지 말고 delete 함수 자체에서 분기를 해서 호출을 해버릴 수는 없을까?

- 해결 
  - memo delete 함수에서 memoId를 반환했었는데, 이걸 weatherId로 고쳤다! 이유는, 이미 메모아이디가 삭제된 상황이어가지구 뒤에 로직들이 중첩되어서 밀린게 원인이었다. 
  - 그리고 weather 서비스에 웨더 update 메소드를 추가했다. (수정에서도 이걸 호출하면 될듯)

## Main Features
- 
- 
- 

## Others
- 
- 
- 
